### PR TITLE
修复通过apache反代挂载导致的webdav无法进行重命名/移动操作问题

### DIFF
--- a/docs/guide/install/reverse-proxy.md
+++ b/docs/guide/install/reverse-proxy.md
@@ -60,14 +60,16 @@ proxy_max_temp_file_size 0; # Add this line
 
 ### **Apache**
 Add the anti-generation configuration item ProxyPass under the VirtualHost field, such as:
-```xml
+```conf
 <VirtualHost *:80>
     ServerName myapp.example.com
     ServerAdmin webmaster@example.com
     DocumentRoot /www/myapp/public
 
     AllowEncodedSlashes NoDecode
+    ProxyPreserveHost On
     ProxyPass "/" "http://127.0.0.1:5244/" nocanon
+    ProxyPassReverse "/" "http://127.0.0.1:5244/" nocanon
 </VirtualHost>
 ```
 

--- a/docs/guide/install/reverse-proxy.md
+++ b/docs/guide/install/reverse-proxy.md
@@ -60,7 +60,7 @@ proxy_max_temp_file_size 0; # Add this line
 
 ### **Apache**
 Add the anti-generation configuration item ProxyPass under the VirtualHost field, such as:
-```conf
+```xml
 <VirtualHost *:80>
     ServerName myapp.example.com
     ServerAdmin webmaster@example.com

--- a/docs/zh/guide/install/reverse-proxy.md
+++ b/docs/zh/guide/install/reverse-proxy.md
@@ -84,7 +84,9 @@ proxy_max_temp_file_size 0; #加上这一行
     DocumentRoot /www/myapp/public
 
     AllowEncodedSlashes NoDecode
+    ProxyPreserveHost On
     ProxyPass "/" "http://127.0.0.1:5244/" nocanon
+    ProxyPassReverse "/" "http://127.0.0.1:5244/" nocanon
 </VirtualHost>
 ```
 


### PR DESCRIPTION
见https://github.com/AlistGo/alist/discussions/3302
实测更改有效
![截图 2025-01-24 22-34-18](https://github.com/user-attachments/assets/a48e2d37-daaa-4f9b-8cc7-a32b1cc85521)
![截图 2025-01-24 22-34-57](https://github.com/user-attachments/assets/e06df566-ad67-4a2c-a667-7b66adefb50a)
