### PR TITLE
Update v3.sh（https://mirror.ghproxy.com/已经无法使用，会导致解压失败）

### DIFF
--- a/docs/.vuepress/public/v3.sh
+++ b/docs/.vuepress/public/v3.sh
@@ -38,7 +38,7 @@ fi
 # 配置部分
 #######################
 # GitHub 相关配置
-GH_PROXY='https://mirror.ghproxy.com/'  # 可以修改为其他代理地址，如果不需要代理可以设置为空
+GH_PROXY=''  # 可以修改为其他代理地址，如果不需要代理可以设置为空
 GH_DOWNLOAD_URL="${GH_PROXY}https://github.com/alist-org/alist/releases/latest/download"
 #######################
 


### PR DESCRIPTION
https://mirror.ghproxy.com/已经无法使用，会导致解压失败
![d250bf13-4645-4b5d-acbf-38b5fd8d6a57](https://github.com/user-attachments/assets/93b2a84f-f613-48f6-a7e5-821370ccd4ed)
