### PR TITLE
向 ecosystem 增加一个Python的SDK项目

### DIFF
--- a/ecosystem.json
+++ b/ecosystem.json
@@ -1,7 +1,7 @@
 {
   "official": [
-    { "type": "github", "repo": "alist-org/alist-proxy" },
-    { "type": "github", "repo": "alist-org/with_aria2" }
+    { "type": "github", "repo": "AlistGo/alist-proxy" },
+    { "type": "github", "repo": "AlistGo/with_aria2" }
   ],
   "community": [
     { "type": "github", "repo": "jinzhi0123/picgo-plugin-alist" },

--- a/ecosystem.json
+++ b/ecosystem.json
@@ -12,6 +12,7 @@
     { "type": "github", "repo": "msterzhang/onelist" },
     { "type": "github", "repo": "moyanj/AList3SDK" },
     { "type": "github", "repo": "lym12321/Alist-SDK" },
+    { "type": "github", "repo": "lee-cq/alist-sdk" },
     { "type": "github", "repo": "power721/alist-tvbox" },
     { "type": "github", "repo": "everstu/Koolcenter_alist" },
     { "type": "github", "repo": "jing332/AListFlutter" },


### PR DESCRIPTION
向 ecosystem 增加一个alist-sdk项目，该项目同时支持异步和同步调用，同时实现了pathlib相关接口，体验接近原生的pathlib库。