### PR TITLE
fix(docker): always use the "latest" tag in minimal examples

### DIFF
--- a/docs/guide/install/docker.md
+++ b/docs/guide/install/docker.md
@@ -32,7 +32,7 @@ docker run -d --restart=unless-stopped -v /etc/alist:/opt/alist/data -p 5244:524
 version: '3.3'
 services:
   alist:
-    image: 'xhofe/alist:beta'
+    image: 'xhofe/alist:latest'
     container_name: alist
     volumes:
       - '/etc/alist:/opt/alist/data'

--- a/docs/zh/guide/install/docker.md
+++ b/docs/zh/guide/install/docker.md
@@ -32,7 +32,7 @@ docker run -d --restart=unless-stopped -v /etc/alist:/opt/alist/data -p 5244:524
 version: '3.3'
 services:
   alist:
-    image: 'xhofe/alist:beta'
+    image: 'xhofe/alist:latest'
     container_name: alist
     volumes:
       - '/etc/alist:/opt/alist/data'


### PR DESCRIPTION
Hello! This is a minor fix about the tag name of docker images.