### PR TITLE
Update script.md

### DIFF
--- a/docs/zh/guide/install/script.md
+++ b/docs/zh/guide/install/script.md
@@ -67,9 +67,9 @@ curl -fsSL "https://alistgo.com/beta.sh" | bash -s uninstall
 # Install
 curl -fsSL "https://alistgo.com/v3.sh" -o v3.sh && bash v3.sh install /root
 # update
-curl -fsSL "https://alistgo.com/v3.sh" -o v3.sh && bash v3.sh update /root
+curl -fsSL "https://alistgo.com/v3.sh" -o v3.sh && bash v3.sh update
 # Uninstall
-curl -fsSL "https://alistgo.com/v3.sh" -o v3.sh && bash v3.sh uninstall /root
+curl -fsSL "https://alistgo.com/v3.sh" -o v3.sh && bash v3.sh uninstall
 ```
 
 @tab 测试版


### PR DESCRIPTION
v3.sh脚本内容已更新，"update"和"uninstall"操作不需要指定目录，原命令已失效，更正为新命令。

v3.sh新版相关段落：

elif [ "$1" = "update" ]; then
  if [ $# -gt 1 ]; then
    echo -e "${RED_COLOR}错误：update 命令不需要指定路径${RES}"
    echo -e "正确用法: $0 update"
    exit 1
  fi
  UPDATE
elif [ "$1" = "uninstall" ]; then
  if [ $# -gt 1 ]; then
    echo -e "${RED_COLOR}错误：uninstall 命令不需要指定路径${RES}"
    echo -e "正确用法: $0 uninstall"
    exit 1
  fi